### PR TITLE
Add support of setting up max group level

### DIFF
--- a/examples/dnd/src/App.tsx
+++ b/examples/dnd/src/App.tsx
@@ -23,7 +23,7 @@ export const App = () => {
   return (
     <div>
       <QueryBuilderDnD>
-        <QueryBuilder fields={fields} query={query} onQueryChange={setQuery} />
+        <QueryBuilder fields={fields} query={query} onQueryChange={setQuery} maxGroupLevel={4} />
       </QueryBuilderDnD>
       <h4>Query</h4>
       <pre>

--- a/packages/dnd/src/hooks/useDragCommon.ts
+++ b/packages/dnd/src/hooks/useDragCommon.ts
@@ -70,7 +70,7 @@ export const useDragCommon = ({
             }
           }
         } else {
-          actions.moveRule(item.path, destinationPath, dropResult.dropEffect === 'copy');
+          actions.moveRule(item.path, destinationPath, dropResult.dropEffect === 'copy', schema.maxGroupLevel);
         }
       },
     }),

--- a/packages/react-querybuilder/src/components/RuleGroup.tsx
+++ b/packages/react-querybuilder/src/components/RuleGroup.tsx
@@ -189,7 +189,7 @@ export const RuleGroupHeaderComponents = React.memo(
           rules={rg.ruleGroup.rules}
           level={rg.path.length}
           path={rg.path}
-          disabled={rg.disabled}
+          disabled={rg.disabled || rg.path.length >= rg.schema.maxGroupLevel}
           context={rg.context}
           validation={rg.validationResult}
           ruleOrGroup={rg.ruleGroup}

--- a/packages/react-querybuilder/src/hooks/useMergedContext.ts
+++ b/packages/react-querybuilder/src/hooks/useMergedContext.ts
@@ -3,16 +3,16 @@ import { forwardRef, useContext, useMemo } from 'react';
 import { QueryBuilderContext, defaultControlElements } from '../components';
 import { defaultControlClassnames, defaultTranslations } from '../defaults';
 import type {
+  ControlElementsProp,
   Controls,
-  FullField,
+  DragHandleProps,
   FieldSelectorProps,
+  FullField,
   OperatorSelectorProps,
   QueryBuilderContextProps,
+  RuleGroupTypeAny,
   TranslationsFull,
   ValueSourceSelectorProps,
-  ControlElementsProp,
-  DragHandleProps,
-  RuleGroupTypeAny,
 } from '../types';
 import { mergeClassnames, mergeTranslations } from '../utils';
 import { usePreferProp } from './usePreferProp';
@@ -52,6 +52,12 @@ export const useMergedContext = <F extends FullField = FullField, O extends stri
     rqbContext.enableDragAndDrop !== false;
 
   const debugMode = usePreferProp(false, props.debugMode, rqbContext.debugMode);
+
+  const maxGroupLevel = useMemo(
+    () =>
+      props.maxGroupLevel === undefined ? Infinity : props.maxGroupLevel,
+    [props.maxGroupLevel]
+  );
 
   const controlClassnames = useMemo(
     () =>
@@ -106,75 +112,75 @@ export const useMergedContext = <F extends FullField = FullField, O extends stri
         : {}),
       ...(rqbContext.controlElements?.actionElement
         ? {
-            addGroupAction:
-              rqbContext.controlElements?.addGroupAction === null
-                ? nullComp
-                : rqbContext.controlElements?.addGroupAction ??
-                  rqbContext.controlElements.actionElement,
-            addRuleAction:
-              rqbContext.controlElements?.addRuleAction === null
-                ? nullComp
-                : rqbContext.controlElements?.addRuleAction ??
-                  rqbContext.controlElements.actionElement,
-            cloneGroupAction:
-              rqbContext.controlElements?.cloneGroupAction === null
-                ? nullComp
-                : rqbContext.controlElements?.cloneGroupAction ??
-                  rqbContext.controlElements.actionElement,
-            cloneRuleAction:
-              rqbContext.controlElements?.cloneRuleAction === null
-                ? nullComp
-                : rqbContext.controlElements?.cloneRuleAction ??
-                  rqbContext.controlElements.actionElement,
-            lockGroupAction:
-              rqbContext.controlElements?.lockGroupAction === null
-                ? nullComp
-                : rqbContext.controlElements?.lockGroupAction ??
-                  rqbContext.controlElements.actionElement,
-            lockRuleAction:
-              rqbContext.controlElements?.lockRuleAction === null
-                ? nullComp
-                : rqbContext.controlElements?.lockRuleAction ??
-                  rqbContext.controlElements.actionElement,
-            removeGroupAction:
-              rqbContext.controlElements?.removeGroupAction === null
-                ? nullComp
-                : rqbContext.controlElements?.removeGroupAction ??
-                  rqbContext.controlElements.actionElement,
-            removeRuleAction:
-              rqbContext.controlElements?.removeRuleAction === null
-                ? nullComp
-                : rqbContext.controlElements?.removeRuleAction ??
-                  rqbContext.controlElements.actionElement,
-          }
+          addGroupAction:
+            rqbContext.controlElements?.addGroupAction === null
+              ? nullComp
+              : rqbContext.controlElements?.addGroupAction ??
+              rqbContext.controlElements.actionElement,
+          addRuleAction:
+            rqbContext.controlElements?.addRuleAction === null
+              ? nullComp
+              : rqbContext.controlElements?.addRuleAction ??
+              rqbContext.controlElements.actionElement,
+          cloneGroupAction:
+            rqbContext.controlElements?.cloneGroupAction === null
+              ? nullComp
+              : rqbContext.controlElements?.cloneGroupAction ??
+              rqbContext.controlElements.actionElement,
+          cloneRuleAction:
+            rqbContext.controlElements?.cloneRuleAction === null
+              ? nullComp
+              : rqbContext.controlElements?.cloneRuleAction ??
+              rqbContext.controlElements.actionElement,
+          lockGroupAction:
+            rqbContext.controlElements?.lockGroupAction === null
+              ? nullComp
+              : rqbContext.controlElements?.lockGroupAction ??
+              rqbContext.controlElements.actionElement,
+          lockRuleAction:
+            rqbContext.controlElements?.lockRuleAction === null
+              ? nullComp
+              : rqbContext.controlElements?.lockRuleAction ??
+              rqbContext.controlElements.actionElement,
+          removeGroupAction:
+            rqbContext.controlElements?.removeGroupAction === null
+              ? nullComp
+              : rqbContext.controlElements?.removeGroupAction ??
+              rqbContext.controlElements.actionElement,
+          removeRuleAction:
+            rqbContext.controlElements?.removeRuleAction === null
+              ? nullComp
+              : rqbContext.controlElements?.removeRuleAction ??
+              rqbContext.controlElements.actionElement,
+        }
         : {}),
       ...(rqbContext.controlElements?.valueSelector
         ? {
-            combinatorSelector:
-              rqbContext.controlElements?.combinatorSelector === null
-                ? nullComp
-                : rqbContext.controlElements?.combinatorSelector ??
-                  rqbContext.controlElements.valueSelector,
-            fieldSelector:
-              rqbContext.controlElements?.fieldSelector === null
-                ? nullComp
-                : rqbContext.controlElements?.fieldSelector ??
-                  (rqbContext.controlElements.valueSelector as unknown as ComponentType<
-                    FieldSelectorProps<F>
-                  >),
-            operatorSelector:
-              rqbContext.controlElements?.operatorSelector === null
-                ? nullComp
-                : rqbContext.controlElements?.operatorSelector ??
-                  (rqbContext.controlElements
-                    .valueSelector as ComponentType<OperatorSelectorProps>),
-            valueSourceSelector:
-              rqbContext.controlElements?.valueSourceSelector === null
-                ? nullComp
-                : rqbContext.controlElements?.valueSourceSelector ??
-                  (rqbContext.controlElements
-                    .valueSelector as ComponentType<ValueSourceSelectorProps>),
-          }
+          combinatorSelector:
+            rqbContext.controlElements?.combinatorSelector === null
+              ? nullComp
+              : rqbContext.controlElements?.combinatorSelector ??
+              rqbContext.controlElements.valueSelector,
+          fieldSelector:
+            rqbContext.controlElements?.fieldSelector === null
+              ? nullComp
+              : rqbContext.controlElements?.fieldSelector ??
+              (rqbContext.controlElements.valueSelector as unknown as ComponentType<
+                FieldSelectorProps<F>
+              >),
+          operatorSelector:
+            rqbContext.controlElements?.operatorSelector === null
+              ? nullComp
+              : rqbContext.controlElements?.operatorSelector ??
+              (rqbContext.controlElements
+                .valueSelector as ComponentType<OperatorSelectorProps>),
+          valueSourceSelector:
+            rqbContext.controlElements?.valueSourceSelector === null
+              ? nullComp
+              : rqbContext.controlElements?.valueSourceSelector ??
+              (rqbContext.controlElements
+                .valueSelector as ComponentType<ValueSourceSelectorProps>),
+        }
         : {}),
     };
 
@@ -206,64 +212,64 @@ export const useMergedContext = <F extends FullField = FullField, O extends stri
         : {}),
       ...(props.controlElements?.actionElement
         ? {
-            addGroupAction:
-              props.controlElements?.addGroupAction === null
-                ? nullComp
-                : props.controlElements?.addGroupAction ?? props.controlElements.actionElement,
-            addRuleAction:
-              props.controlElements?.addRuleAction === null
-                ? nullComp
-                : props.controlElements?.addRuleAction ?? props.controlElements.actionElement,
-            cloneGroupAction:
-              props.controlElements?.cloneGroupAction === null
-                ? nullComp
-                : props.controlElements?.cloneGroupAction ?? props.controlElements.actionElement,
-            cloneRuleAction:
-              props.controlElements?.cloneRuleAction === null
-                ? nullComp
-                : props.controlElements?.cloneRuleAction ?? props.controlElements.actionElement,
-            lockGroupAction:
-              props.controlElements?.lockGroupAction === null
-                ? nullComp
-                : props.controlElements?.lockGroupAction ?? props.controlElements.actionElement,
-            lockRuleAction:
-              props.controlElements?.lockRuleAction === null
-                ? nullComp
-                : props.controlElements?.lockRuleAction ?? props.controlElements.actionElement,
-            removeGroupAction:
-              props.controlElements?.removeGroupAction === null
-                ? nullComp
-                : props.controlElements?.removeGroupAction ?? props.controlElements.actionElement,
-            removeRuleAction:
-              props.controlElements?.removeRuleAction === null
-                ? nullComp
-                : props.controlElements?.removeRuleAction ?? props.controlElements.actionElement,
-          }
+          addGroupAction:
+            props.controlElements?.addGroupAction === null
+              ? nullComp
+              : props.controlElements?.addGroupAction ?? props.controlElements.actionElement,
+          addRuleAction:
+            props.controlElements?.addRuleAction === null
+              ? nullComp
+              : props.controlElements?.addRuleAction ?? props.controlElements.actionElement,
+          cloneGroupAction:
+            props.controlElements?.cloneGroupAction === null
+              ? nullComp
+              : props.controlElements?.cloneGroupAction ?? props.controlElements.actionElement,
+          cloneRuleAction:
+            props.controlElements?.cloneRuleAction === null
+              ? nullComp
+              : props.controlElements?.cloneRuleAction ?? props.controlElements.actionElement,
+          lockGroupAction:
+            props.controlElements?.lockGroupAction === null
+              ? nullComp
+              : props.controlElements?.lockGroupAction ?? props.controlElements.actionElement,
+          lockRuleAction:
+            props.controlElements?.lockRuleAction === null
+              ? nullComp
+              : props.controlElements?.lockRuleAction ?? props.controlElements.actionElement,
+          removeGroupAction:
+            props.controlElements?.removeGroupAction === null
+              ? nullComp
+              : props.controlElements?.removeGroupAction ?? props.controlElements.actionElement,
+          removeRuleAction:
+            props.controlElements?.removeRuleAction === null
+              ? nullComp
+              : props.controlElements?.removeRuleAction ?? props.controlElements.actionElement,
+        }
         : {}),
       ...(props.controlElements?.valueSelector
         ? {
-            combinatorSelector:
-              props.controlElements?.combinatorSelector === null
-                ? nullComp
-                : props.controlElements?.combinatorSelector ?? props.controlElements.valueSelector,
-            fieldSelector:
-              props.controlElements?.fieldSelector === null
-                ? nullComp
-                : props.controlElements?.fieldSelector ??
-                  (props.controlElements.valueSelector as unknown as ComponentType<
-                    FieldSelectorProps<F>
-                  >),
-            operatorSelector:
-              props.controlElements?.operatorSelector === null
-                ? nullComp
-                : props.controlElements?.operatorSelector ??
-                  (props.controlElements.valueSelector as ComponentType<OperatorSelectorProps>),
-            valueSourceSelector:
-              props.controlElements?.valueSourceSelector === null
-                ? nullComp
-                : props.controlElements?.valueSourceSelector ??
-                  (props.controlElements.valueSelector as ComponentType<ValueSourceSelectorProps>),
-          }
+          combinatorSelector:
+            props.controlElements?.combinatorSelector === null
+              ? nullComp
+              : props.controlElements?.combinatorSelector ?? props.controlElements.valueSelector,
+          fieldSelector:
+            props.controlElements?.fieldSelector === null
+              ? nullComp
+              : props.controlElements?.fieldSelector ??
+              (props.controlElements.valueSelector as unknown as ComponentType<
+                FieldSelectorProps<F>
+              >),
+          operatorSelector:
+            props.controlElements?.operatorSelector === null
+              ? nullComp
+              : props.controlElements?.operatorSelector ??
+              (props.controlElements.valueSelector as ComponentType<OperatorSelectorProps>),
+          valueSourceSelector:
+            props.controlElements?.valueSourceSelector === null
+              ? nullComp
+              : props.controlElements?.valueSourceSelector ??
+              (props.controlElements.valueSelector as ComponentType<ValueSourceSelectorProps>),
+        }
         : {}),
     };
 
@@ -299,6 +305,7 @@ export const useMergedContext = <F extends FullField = FullField, O extends stri
     controlElements,
     debugMode,
     enableDragAndDrop,
+    maxGroupLevel,
     enableMountQueryChange,
     translations,
     initialQuery: props.initialQuery,

--- a/packages/react-querybuilder/src/hooks/useQueryBuilderSchema.ts
+++ b/packages/react-querybuilder/src/hooks/useQueryBuilderSchema.ts
@@ -100,6 +100,7 @@ export function useQueryBuilderSchema<
     onLog = defaultOnLog,
     idGenerator,
     accessibleDescriptionGenerator = generateAccessibleDescription,
+    maxGroupLevel = Infinity
   } = props;
 
   const {
@@ -125,7 +126,7 @@ export function useQueryBuilderSchema<
     debugMode,
     enableDragAndDrop,
     enableMountQueryChange,
-    translations,
+    translations
   } = incomingRqbContext;
 
   // #region Boolean coercion
@@ -400,7 +401,7 @@ export function useQueryBuilderSchema<
   );
 
   const moveRule = useCallback(
-    (oldPath: Path, newPath: Path, clone?: boolean) => {
+    (oldPath: Path, newPath: Path, clone?: boolean, maxGroupLevel?: number) => {
       const queryLocal = getQuerySelectorById(qbId)(queryBuilderStore.getState());
       // istanbul ignore if
       if (!queryLocal) return;
@@ -411,7 +412,7 @@ export function useQueryBuilderSchema<
         }
         return;
       }
-      const newQuery = move(queryLocal, oldPath, newPath, { clone, combinators });
+      const newQuery = move(queryLocal, oldPath, newPath, { clone, combinators, maxGroupLevel });
       if (debugMode) {
         onLog({ qbId, type: LogType.move, query: queryLocal, newQuery, oldPath, newPath, clone });
       }
@@ -455,6 +456,7 @@ export function useQueryBuilderSchema<
       createRuleGroup,
       disabledPaths,
       enableDragAndDrop,
+      maxGroupLevel,
       fieldMap: fieldMap as FullOptionMap<F>,
       fields,
       dispatchQuery,
@@ -490,6 +492,7 @@ export function useQueryBuilderSchema<
       createRuleGroup,
       disabledPaths,
       enableDragAndDrop,
+      maxGroupLevel,
       fieldMap,
       fields,
       dispatchQuery,

--- a/packages/react-querybuilder/src/hooks/useQueryBuilderSetup.ts
+++ b/packages/react-querybuilder/src/hooks/useQueryBuilderSetup.ts
@@ -41,9 +41,9 @@ const getFirstOptionsFrom = (opts: any[], r: RuleType, listsAsArrays?: boolean) 
     return listsAsArrays
       ? valueAsArray
       : joinWith(
-          valueAsArray.map(v => v ?? /* istanbul ignore next */ ''),
-          ','
-        );
+        valueAsArray.map(v => v ?? /* istanbul ignore next */ ''),
+        ','
+      );
   }
 
   return firstOption;
@@ -90,6 +90,7 @@ export const useQueryBuilderSetup = <
     autoSelectOperator = true,
     addRuleToNewGroups = false,
     enableDragAndDrop: enableDragAndDropProp,
+    maxGroupLevel = Infinity,
     listsAsArrays = false,
     debugMode: debugModeProp = false,
     idGenerator = generateID,
@@ -104,6 +105,7 @@ export const useQueryBuilderSetup = <
     controlElements: controlElementsProp,
     debugMode: debugModeProp,
     enableDragAndDrop: enableDragAndDropProp,
+    maxGroupLevel,
     enableMountQueryChange: enableMountQueryChangeProp,
     translations: translationsProp,
     initialQuery: initialQueryProp,
@@ -133,8 +135,8 @@ export const useQueryBuilderSetup = <
       Array.isArray(fieldsProp)
         ? toFullOptionList(fieldsProp, baseField)
         : objectKeys(toFullOptionMap(fieldsProp, baseField))
-            .map(fld => ({ ...fieldsProp[fld as unknown as FieldName], name: fld, value: fld }))
-            .sort((a, b) => a.label.localeCompare(b.label))
+          .map(fld => ({ ...fieldsProp[fld as unknown as FieldName], name: fld, value: fld }))
+          .sort((a, b) => a.label.localeCompare(b.label))
     ) as FullOptionList<F>;
     if (isFlexibleOptionGroupArray(flds)) {
       if (autoSelectField) {
@@ -272,7 +274,7 @@ export const useQueryBuilderSetup = <
         }
       }
 
-      const ops = getOperatorsMain(field, { fieldData }) ?? /* istanbul ignore next */ [];
+      const ops = getOperatorsMain(field, { fieldData }) ?? /* istanbul ignore next */[];
       return (getFirstOption(ops) ?? /* istanbul ignore next */ '') as OperatorName;
     },
     [fieldMap, getDefaultOperator, getOperatorsMain]

--- a/packages/react-querybuilder/src/hooks/useRule.ts
+++ b/packages/react-querybuilder/src/hooks/useRule.ts
@@ -50,6 +50,7 @@ export const useRule = (props: RuleProps) => {
     validationMap,
     enableDragAndDrop,
     getRuleClassname,
+    maxGroupLevel
   } = schema;
 
   useDeprecatedProps('rule', !ruleProp);
@@ -63,12 +64,12 @@ export const useRule = (props: RuleProps) => {
       ruleProp
         ? ruleProp
         : {
-            id,
-            field: fieldProp ?? /* istanbul ignore next */ '',
-            operator: operatorProp ?? /* istanbul ignore next */ '',
-            value: valueProp,
-            valueSource: valueSourceProp,
-          },
+          id,
+          field: fieldProp ?? /* istanbul ignore next */ '',
+          operator: operatorProp ?? /* istanbul ignore next */ '',
+          value: valueProp,
+          valueSource: valueSourceProp,
+        },
     [fieldProp, id, operatorProp, ruleProp, valueProp, valueSourceProp]
   );
 
@@ -134,10 +135,10 @@ export const useRule = (props: RuleProps) => {
     (_event?: any, _context?: any) => {
       if (!disabled) {
         const newPath = [...getParentPath(path), path[path.length - 1] + 1];
-        moveRule(path, newPath, true);
+        moveRule(path, newPath, true, maxGroupLevel);
       }
     },
-    [disabled, moveRule, path]
+    [disabled, moveRule, path, maxGroupLevel]
   );
 
   const toggleLockRule = useCallback(
@@ -162,20 +163,20 @@ export const useRule = (props: RuleProps) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (event?: MouseEvent, _context?: any) => {
       if (!disabled && !shiftUpDisabled) {
-        moveRule(path, 'up', event?.altKey);
+        moveRule(path, 'up', event?.altKey, maxGroupLevel);
       }
     },
-    [disabled, moveRule, path, shiftUpDisabled]
+    [disabled, moveRule, path, shiftUpDisabled, maxGroupLevel]
   );
 
   const shiftRuleDown = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (event?: MouseEvent, _context?: any) => {
       if (!disabled && !shiftDownDisabled) {
-        moveRule(path, 'down', event?.altKey);
+        moveRule(path, 'down', event?.altKey, maxGroupLevel);
       }
     },
-    [disabled, moveRule, path, shiftDownDisabled]
+    [disabled, moveRule, path, shiftDownDisabled, maxGroupLevel]
   );
 
   const fieldData: FullField = useMemo(

--- a/packages/react-querybuilder/src/hooks/useRuleGroup.ts
+++ b/packages/react-querybuilder/src/hooks/useRuleGroup.ts
@@ -33,6 +33,7 @@ export const useRuleGroup = (props: RuleGroupProps) => {
       validationMap,
       enableDragAndDrop,
       getRuleGroupClassname,
+      maxGroupLevel
     },
     actions: { onGroupAdd, onGroupRemove, onPropChange, onRuleAdd, moveRule },
     disabled: disabledProp,
@@ -194,30 +195,30 @@ export const useRuleGroup = (props: RuleGroupProps) => {
     (_event?: any, _context?: any) => {
       if (!disabled) {
         const newPath = [...getParentPath(path), path[path.length - 1] + 1];
-        moveRule(path, newPath, true);
+        moveRule(path, newPath, true, maxGroupLevel);
       }
     },
-    [disabled, moveRule, path]
+    [disabled, moveRule, path, maxGroupLevel]
   );
 
   const shiftGroupUp = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (event?: MouseEvent, _context?: any) => {
       if (!disabled && !shiftUpDisabled) {
-        moveRule(path, 'up', event?.altKey);
+        moveRule(path, 'up', event?.altKey, maxGroupLevel);
       }
     },
-    [disabled, moveRule, path, shiftUpDisabled]
+    [disabled, moveRule, path, shiftUpDisabled, maxGroupLevel]
   );
 
   const shiftGroupDown = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (event?: MouseEvent, _context?: any) => {
       if (!disabled && !shiftDownDisabled) {
-        moveRule(path, 'down', event?.altKey);
+        moveRule(path, 'down', event?.altKey, maxGroupLevel);
       }
     },
-    [disabled, moveRule, path, shiftDownDisabled]
+    [disabled, moveRule, path, shiftDownDisabled, maxGroupLevel]
   );
 
   const toggleLockGroup = useCallback(

--- a/packages/react-querybuilder/src/types/props.ts
+++ b/packages/react-querybuilder/src/types/props.ts
@@ -109,7 +109,7 @@ export interface CombinatorSelectorProps extends BaseSelectorProps<FullOption> {
  */
 export interface FieldSelectorProps<F extends FullField = FullField>
   extends BaseSelectorProps<F>,
-    CommonRuleSubComponentProps {
+  CommonRuleSubComponentProps {
   operator?: F extends FullField<string, infer OperatorName> ? OperatorName : string;
 }
 
@@ -118,7 +118,7 @@ export interface FieldSelectorProps<F extends FullField = FullField>
  */
 export interface OperatorSelectorProps
   extends BaseSelectorProps<FullOption>,
-    CommonRuleSubComponentProps {
+  CommonRuleSubComponentProps {
   options: FullOptionList<FullOperator>;
   field: string;
   fieldData: FullField;
@@ -129,7 +129,7 @@ export interface OperatorSelectorProps
  */
 export interface ValueSourceSelectorProps
   extends BaseSelectorProps<FullOption>,
-    CommonRuleSubComponentProps {
+  CommonRuleSubComponentProps {
   options: FullOptionList<FullOption<ValueSource>>;
   field: string;
   fieldData: FullField;
@@ -258,7 +258,7 @@ export interface QueryActions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onRuleAdd(rule: RuleType, parentPath: Path, context?: any): void;
   onRuleRemove(path: Path): void;
-  moveRule(oldPath: Path, newPath: Path | 'up' | 'down', clone?: boolean): void;
+  moveRule(oldPath: Path, newPath: Path | 'up' | 'down', clone?: boolean, maxGroupLevel?: number): void;
 }
 
 /**

--- a/packages/react-querybuilder/src/types/propsUsingReact.ts
+++ b/packages/react-querybuilder/src/types/propsUsingReact.ts
@@ -12,8 +12,8 @@ import type {
   Classname,
   FullCombinator,
   FullField,
-  InputType,
   FullOperator,
+  InputType,
   ParseNumbersMethod,
   Path,
   ValueEditorType,
@@ -22,8 +22,8 @@ import type {
 } from './basic';
 import type { DropEffect } from './dnd';
 import type {
-  FlexibleOptionList,
   BaseOptionMap,
+  FlexibleOptionList,
   FullOption,
   FullOptionList,
   GetOptionIdentifierType,
@@ -160,7 +160,7 @@ export interface InlineCombinatorProps extends CombinatorSelectorProps {
  */
 export interface ValueEditorProps<F extends FullField = FullField, O extends string = string>
   extends SelectorOrEditorProps<F, O>,
-    CommonRuleSubComponentProps {
+  CommonRuleSubComponentProps {
   field: GetOptionIdentifierType<F>;
   operator: O;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -353,6 +353,7 @@ export interface Schema<F extends FullField, O extends string> {
   autoSelectOperator: boolean;
   addRuleToNewGroups: boolean;
   enableDragAndDrop: boolean;
+  maxGroupLevel: number;
   validationMap: ValidationMap;
   independentCombinators: boolean;
   listsAsArrays: boolean;
@@ -397,7 +398,7 @@ export interface UseRuleGroupDnD {
  */
 export interface RuleGroupProps<F extends FullOption = FullOption, O extends string = string>
   extends CommonRuleAndGroupProps<F, O>,
-    Partial<UseRuleGroupDnD> {
+  Partial<UseRuleGroupDnD> {
   ruleGroup: RuleGroupTypeAny<RuleType<GetOptionIdentifierType<F>, O>>;
   /**
    * @deprecated Use the `combinator` property of the `ruleGroup` prop instead
@@ -432,7 +433,7 @@ export interface UseRuleDnD {
  */
 export interface RuleProps<F extends string = string, O extends string = string>
   extends CommonRuleAndGroupProps<FullOption<F>, O>,
-    Partial<UseRuleDnD> {
+  Partial<UseRuleDnD> {
   rule: RuleType<F, O>;
   /**
    * @deprecated Use the `field` property of the `rule` prop instead
@@ -484,6 +485,13 @@ export interface QueryBuilderContextProps<F extends FullField, O extends string>
    * @default false
    */
   enableDragAndDrop?: boolean;
+
+  /**
+   * Prop to set max grouping level
+   *
+   * @default Infinity
+   */
+  maxGroupLevel?: number;
   /**
    * Enables debug logging for {@link QueryBuilder} (and React DnD when applicable).
    *
@@ -521,307 +529,307 @@ export type QueryBuilderProps<
   C extends FullCombinator,
 > = RG extends RuleGroupType<infer R> | RuleGroupTypeIC<infer R>
   ? QueryBuilderContextProps<F, GetOptionIdentifierType<O>> & {
-      /**
-       * Initial query object for uncontrolled components.
-       */
-      defaultQuery?: RG;
-      /**
-       * Query object for controlled components.
-       */
-      query?: RG;
-      /**
-       * List of valid {@link FullField}s.
-       *
-       * @default []
-       */
-      fields?: FlexibleOptionList<F> | BaseOptionMap<F, GetOptionIdentifierType<F>>;
-      /**
-       * List of valid {@link FullOperator}s.
-       *
-       * @see {@link DefaultOperatorName}
-       *
-       * @default
-       * [
-       *   { name: '=', label: '=' },
-       *   { name: '!=', label: '!=' },
-       *   { name: '<', label: '<' },
-       *   { name: '>', label: '>' },
-       *   { name: '<=', label: '<=' },
-       *   { name: '>=', label: '>=' },
-       *   { name: 'contains', label: 'contains' },
-       *   { name: 'beginsWith', label: 'begins with' },
-       *   { name: 'endsWith', label: 'ends with' },
-       *   { name: 'doesNotContain', label: 'does not contain' },
-       *   { name: 'doesNotBeginWith', label: 'does not begin with' },
-       *   { name: 'doesNotEndWith', label: 'does not end with' },
-       *   { name: 'null', label: 'is null' },
-       *   { name: 'notNull', label: 'is not null' },
-       *   { name: 'in', label: 'in' },
-       *   { name: 'notIn', label: 'not in' },
-       *   { name: 'between', label: 'between' },
-       *   { name: 'notBetween', label: 'not between' },
-       * ]
-       */
-      operators?: FlexibleOptionList<O>;
-      /**
-       * List of valid {@link FullCombinator}s.
-       *
-       * @see {@link DefaultCombinatorName}
-       *
-       * @default
-       * [
-       *   {name: 'and', label: 'AND'},
-       *   {name: 'or', label: 'OR'},
-       * ]
-       */
-      combinators?: FlexibleOptionList<C>;
-      /**
-       * Default properties applied to all objects in the `fields` prop. Properties on
-       * individual field definitions will override these.
-       */
-      baseField?: Record<string, unknown>;
-      /**
-       * Default properties applied to all objects in the `operators` prop. Properties on
-       * individual operator definitions will override these.
-       */
-      baseOperator?: Record<string, unknown>;
-      /**
-       * Default properties applied to all objects in the `combinators` prop. Properties on
-       * individual combinator definitions will override these.
-       */
-      baseCombinator?: Record<string, unknown>;
-      /**
-       * The default `field` value for new rules. This can be the field `name`
-       * itself or a function that returns a valid {@link FullField} `name` given
-       * the `fields` list.
-       */
-      getDefaultField?: GetOptionIdentifierType<F> | ((fieldsData: FullOptionList<F>) => string);
-      /**
-       * The default `operator` value for new rules. This can be the operator
-       * `name` or a function that returns a valid {@link FullOperator} `name` for
-       * a given field name.
-       */
-      getDefaultOperator?:
-        | GetOptionIdentifierType<O>
-        | ((field: GetOptionIdentifierType<F>, misc: { fieldData: F }) => string);
-      /**
-       * Returns the default `value` for new rules.
-       */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      getDefaultValue?(rule: R, misc: { fieldData: F }): any;
-      /**
-       * This function should return the list of allowed {@link FullOperator}s
-       * for the given {@link FullField} `name`. If `null` is returned, the
-       * {@link DefaultOperator}s are used.
-       */
-      getOperators?(
-        field: GetOptionIdentifierType<F>,
-        misc: { fieldData: F }
-      ): FlexibleOptionList<FullOperator> | null;
-      /**
-       * This function should return the type of {@link ValueEditor} (see
-       * {@link ValueEditorType}) for the given field `name` and operator `name`.
-       */
-      getValueEditorType?(
-        field: GetOptionIdentifierType<F>,
-        operator: GetOptionIdentifierType<O>,
-        misc: { fieldData: F }
-      ): ValueEditorType;
-      /**
-       * This function should return the separator element for a given field
-       * `name` and operator `name`. The element can be any valid React element,
-       * including a bare string (e.g., "and" or "to") or an HTML element like
-       * `<span />`. It will be placed in between value editors when multiple
-       * editors are rendered, such as when the `operator` is `"between"`.
-       */
-      getValueEditorSeparator?(
-        field: GetOptionIdentifierType<F>,
-        operator: GetOptionIdentifierType<O>,
-        misc: { fieldData: F }
-      ): ReactNode;
-      /**
-       * This function should return the list of valid {@link ValueSources}
-       * for a given field `name` and operator `name`. The return value must
-       * be an array that includes at least one valid {@link ValueSource}
-       * (i.e. `["value"]`, `["field"]`, `["value", "field"]`, or
-       * `["field", "value"]`).
-       */
-      getValueSources?(
-        field: GetOptionIdentifierType<F>,
-        operator: GetOptionIdentifierType<O>,
-        misc: { fieldData: F }
-      ): ValueSources;
-      /**
-       * This function should return the `type` of `<input />`
-       * for the given field `name` and operator `name` (only applicable when
-       * `getValueEditorType` returns `"text"` or a falsy value). If no
-       * function is provided, `"text"` is used as the default.
-       */
-      getInputType?(
-        field: GetOptionIdentifierType<F>,
-        operator: GetOptionIdentifierType<O>,
-        misc: { fieldData: F }
-      ): InputType | null;
-      /**
-       * This function should return the list of allowed values for the
-       * given field `name` and operator `name` (only applicable when
-       * `getValueEditorType` returns `"select"` or `"radio"`). If no
-       * function is provided, an empty array is used as the default.
-       */
-      getValues?(
-        field: GetOptionIdentifierType<F>,
-        operator: GetOptionIdentifierType<O>,
-        misc: { fieldData: F }
-      ): FlexibleOptionList<Option>;
-      /**
-       * The return value of this function will be used to apply classnames to the
-       * outer `<div>` of the given {@link Rule}.
-       */
-      getRuleClassname?(rule: R, misc: { fieldData: F }): Classname;
-      /**
-       * The return value of this function will be used to apply classnames to the
-       * outer `<div>` of the given {@link RuleGroup}.
-       */
-      getRuleGroupClassname?(ruleGroup: RG): Classname;
-      /**
-       * This callback is invoked before a new rule is added. The function should either manipulate
-       * the rule and return the new object, or return `false` to cancel the addition of the rule.
-       */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onAddRule?(rule: R, parentPath: Path, query: RG, context?: any): RuleType | false;
-      /**
-       * This callback is invoked before a new group is added. The function should either manipulate
-       * the group and return the new object, or return `false` to cancel the addition of the group.
-       */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onAddGroup?(ruleGroup: RG, parentPath: Path, query: RG, context?: any): RG | false;
-      /**
-       * This callback is invoked before a rule or group is removed. The function should return
-       * `true` if the rule or group should be removed or `false` if it should not be removed.
-       */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onRemove?(ruleOrGroup: R | RG, path: Path, query: RG, context?: any): boolean;
-      /**
-       * This callback is invoked anytime the query state is updated.
-       */
-      onQueryChange?(query: RG): void;
-      /**
-       * Each log object will be passed to this function when `debugMode` is `true`.
-       *
-       * @default console.log
-       */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onLog?(obj: any): void;
-      /**
-       * Show group combinator selectors in the body of the group, between each child rule/group,
-       * instead of in the group header.
-       *
-       * @default false
-       */
-      showCombinatorsBetweenRules?: boolean;
-      /**
-       * @deprecated As of v7, this prop is ignored. To enable independent combinators, use
-       * {@link RuleGroupTypeIC} for the `query` or `defaultQuery` prop. The query builder
-       * will detect the query type and behave accordingly.
-       */
-      independentCombinators?: boolean;
-      /**
-       * Show the "not" (aka inversion) toggle for rule groups.
-       *
-       * @default false
-       */
-      showNotToggle?: boolean;
-      /**
-       * Show the "Shift up"/"Shift down" actions.
-       *
-       * @default false
-       */
-      showShiftActions?: boolean;
-      /**
-       * Show the "Clone rule" and "Clone group" buttons.
-       *
-       * @default false
-       */
-      showCloneButtons?: boolean;
-      /**
-       * Show the "Lock rule" and "Lock group" buttons.
-       *
-       * @default false
-       */
-      showLockButtons?: boolean;
-      /**
-       * Reset the `operator` and `value` when the `field` changes.
-       *
-       * @default true
-       */
-      resetOnFieldChange?: boolean;
-      /**
-       * Reset the `value` when the `operator` changes.
-       *
-       * @default false
-       */
-      resetOnOperatorChange?: boolean;
-      /**
-       * Select the first field in the array automatically.
-       *
-       * @default true
-       */
-      autoSelectField?: boolean;
-      /**
-       * Select the first operator in the array automatically.
-       *
-       * @default true
-       */
-      autoSelectOperator?: boolean;
-      /**
-       * Adds a new default rule automatically to each new group.
-       *
-       * @default false
-       */
-      addRuleToNewGroups?: boolean;
-      /**
-       * Store list-type values as native arrays instead of comma-separated strings.
-       *
-       * @default false
-       */
-      listsAsArrays?: boolean;
-      /**
-       * Store values as numbers if possible.
-       *
-       * @default false
-       */
-      parseNumbers?: ParseNumbersMethod;
-      /**
-       * Disables the entire query builder if true, or the rules and groups at
-       * the specified paths (as well as all child rules/groups and subcomponents)
-       * if an array of paths is provided. If the root path is specified (`disabled={[[]]}`),
-       * no changes to the query are allowed.
-       *
-       * @default false
-       */
-      disabled?: boolean | Path[];
-      /**
-       * Query validation function.
-       */
-      validator?: QueryValidator;
-      /**
-       * `id` generator function. Should always produce a unique/random value.
-       *
-       * @default crypto.randomUUID
-       */
-      idGenerator?: () => string;
-      /**
-       * Generator function for the `title` attribute applied to the outermost `<div>` of each
-       * rule group. As this is intended to help with accessibility, the text output from this
-       * function should be meaningful, descriptive, and unique within the page.
-       */
-      accessibleDescriptionGenerator?: AccessibleDescriptionGenerator;
-      /**
-       * Container for custom props that are passed to all components.
-       */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      context?: any;
-    }
+    /**
+     * Initial query object for uncontrolled components.
+     */
+    defaultQuery?: RG;
+    /**
+     * Query object for controlled components.
+     */
+    query?: RG;
+    /**
+     * List of valid {@link FullField}s.
+     *
+     * @default []
+     */
+    fields?: FlexibleOptionList<F> | BaseOptionMap<F, GetOptionIdentifierType<F>>;
+    /**
+     * List of valid {@link FullOperator}s.
+     *
+     * @see {@link DefaultOperatorName}
+     *
+     * @default
+     * [
+     *   { name: '=', label: '=' },
+     *   { name: '!=', label: '!=' },
+     *   { name: '<', label: '<' },
+     *   { name: '>', label: '>' },
+     *   { name: '<=', label: '<=' },
+     *   { name: '>=', label: '>=' },
+     *   { name: 'contains', label: 'contains' },
+     *   { name: 'beginsWith', label: 'begins with' },
+     *   { name: 'endsWith', label: 'ends with' },
+     *   { name: 'doesNotContain', label: 'does not contain' },
+     *   { name: 'doesNotBeginWith', label: 'does not begin with' },
+     *   { name: 'doesNotEndWith', label: 'does not end with' },
+     *   { name: 'null', label: 'is null' },
+     *   { name: 'notNull', label: 'is not null' },
+     *   { name: 'in', label: 'in' },
+     *   { name: 'notIn', label: 'not in' },
+     *   { name: 'between', label: 'between' },
+     *   { name: 'notBetween', label: 'not between' },
+     * ]
+     */
+    operators?: FlexibleOptionList<O>;
+    /**
+     * List of valid {@link FullCombinator}s.
+     *
+     * @see {@link DefaultCombinatorName}
+     *
+     * @default
+     * [
+     *   {name: 'and', label: 'AND'},
+     *   {name: 'or', label: 'OR'},
+     * ]
+     */
+    combinators?: FlexibleOptionList<C>;
+    /**
+     * Default properties applied to all objects in the `fields` prop. Properties on
+     * individual field definitions will override these.
+     */
+    baseField?: Record<string, unknown>;
+    /**
+     * Default properties applied to all objects in the `operators` prop. Properties on
+     * individual operator definitions will override these.
+     */
+    baseOperator?: Record<string, unknown>;
+    /**
+     * Default properties applied to all objects in the `combinators` prop. Properties on
+     * individual combinator definitions will override these.
+     */
+    baseCombinator?: Record<string, unknown>;
+    /**
+     * The default `field` value for new rules. This can be the field `name`
+     * itself or a function that returns a valid {@link FullField} `name` given
+     * the `fields` list.
+     */
+    getDefaultField?: GetOptionIdentifierType<F> | ((fieldsData: FullOptionList<F>) => string);
+    /**
+     * The default `operator` value for new rules. This can be the operator
+     * `name` or a function that returns a valid {@link FullOperator} `name` for
+     * a given field name.
+     */
+    getDefaultOperator?:
+    | GetOptionIdentifierType<O>
+    | ((field: GetOptionIdentifierType<F>, misc: { fieldData: F }) => string);
+    /**
+     * Returns the default `value` for new rules.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getDefaultValue?(rule: R, misc: { fieldData: F }): any;
+    /**
+     * This function should return the list of allowed {@link FullOperator}s
+     * for the given {@link FullField} `name`. If `null` is returned, the
+     * {@link DefaultOperator}s are used.
+     */
+    getOperators?(
+      field: GetOptionIdentifierType<F>,
+      misc: { fieldData: F }
+    ): FlexibleOptionList<FullOperator> | null;
+    /**
+     * This function should return the type of {@link ValueEditor} (see
+     * {@link ValueEditorType}) for the given field `name` and operator `name`.
+     */
+    getValueEditorType?(
+      field: GetOptionIdentifierType<F>,
+      operator: GetOptionIdentifierType<O>,
+      misc: { fieldData: F }
+    ): ValueEditorType;
+    /**
+     * This function should return the separator element for a given field
+     * `name` and operator `name`. The element can be any valid React element,
+     * including a bare string (e.g., "and" or "to") or an HTML element like
+     * `<span />`. It will be placed in between value editors when multiple
+     * editors are rendered, such as when the `operator` is `"between"`.
+     */
+    getValueEditorSeparator?(
+      field: GetOptionIdentifierType<F>,
+      operator: GetOptionIdentifierType<O>,
+      misc: { fieldData: F }
+    ): ReactNode;
+    /**
+     * This function should return the list of valid {@link ValueSources}
+     * for a given field `name` and operator `name`. The return value must
+     * be an array that includes at least one valid {@link ValueSource}
+     * (i.e. `["value"]`, `["field"]`, `["value", "field"]`, or
+     * `["field", "value"]`).
+     */
+    getValueSources?(
+      field: GetOptionIdentifierType<F>,
+      operator: GetOptionIdentifierType<O>,
+      misc: { fieldData: F }
+    ): ValueSources;
+    /**
+     * This function should return the `type` of `<input />`
+     * for the given field `name` and operator `name` (only applicable when
+     * `getValueEditorType` returns `"text"` or a falsy value). If no
+     * function is provided, `"text"` is used as the default.
+     */
+    getInputType?(
+      field: GetOptionIdentifierType<F>,
+      operator: GetOptionIdentifierType<O>,
+      misc: { fieldData: F }
+    ): InputType | null;
+    /**
+     * This function should return the list of allowed values for the
+     * given field `name` and operator `name` (only applicable when
+     * `getValueEditorType` returns `"select"` or `"radio"`). If no
+     * function is provided, an empty array is used as the default.
+     */
+    getValues?(
+      field: GetOptionIdentifierType<F>,
+      operator: GetOptionIdentifierType<O>,
+      misc: { fieldData: F }
+    ): FlexibleOptionList<Option>;
+    /**
+     * The return value of this function will be used to apply classnames to the
+     * outer `<div>` of the given {@link Rule}.
+     */
+    getRuleClassname?(rule: R, misc: { fieldData: F }): Classname;
+    /**
+     * The return value of this function will be used to apply classnames to the
+     * outer `<div>` of the given {@link RuleGroup}.
+     */
+    getRuleGroupClassname?(ruleGroup: RG): Classname;
+    /**
+     * This callback is invoked before a new rule is added. The function should either manipulate
+     * the rule and return the new object, or return `false` to cancel the addition of the rule.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onAddRule?(rule: R, parentPath: Path, query: RG, context?: any): RuleType | false;
+    /**
+     * This callback is invoked before a new group is added. The function should either manipulate
+     * the group and return the new object, or return `false` to cancel the addition of the group.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onAddGroup?(ruleGroup: RG, parentPath: Path, query: RG, context?: any): RG | false;
+    /**
+     * This callback is invoked before a rule or group is removed. The function should return
+     * `true` if the rule or group should be removed or `false` if it should not be removed.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onRemove?(ruleOrGroup: R | RG, path: Path, query: RG, context?: any): boolean;
+    /**
+     * This callback is invoked anytime the query state is updated.
+     */
+    onQueryChange?(query: RG): void;
+    /**
+     * Each log object will be passed to this function when `debugMode` is `true`.
+     *
+     * @default console.log
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onLog?(obj: any): void;
+    /**
+     * Show group combinator selectors in the body of the group, between each child rule/group,
+     * instead of in the group header.
+     *
+     * @default false
+     */
+    showCombinatorsBetweenRules?: boolean;
+    /**
+     * @deprecated As of v7, this prop is ignored. To enable independent combinators, use
+     * {@link RuleGroupTypeIC} for the `query` or `defaultQuery` prop. The query builder
+     * will detect the query type and behave accordingly.
+     */
+    independentCombinators?: boolean;
+    /**
+     * Show the "not" (aka inversion) toggle for rule groups.
+     *
+     * @default false
+     */
+    showNotToggle?: boolean;
+    /**
+     * Show the "Shift up"/"Shift down" actions.
+     *
+     * @default false
+     */
+    showShiftActions?: boolean;
+    /**
+     * Show the "Clone rule" and "Clone group" buttons.
+     *
+     * @default false
+     */
+    showCloneButtons?: boolean;
+    /**
+     * Show the "Lock rule" and "Lock group" buttons.
+     *
+     * @default false
+     */
+    showLockButtons?: boolean;
+    /**
+     * Reset the `operator` and `value` when the `field` changes.
+     *
+     * @default true
+     */
+    resetOnFieldChange?: boolean;
+    /**
+     * Reset the `value` when the `operator` changes.
+     *
+     * @default false
+     */
+    resetOnOperatorChange?: boolean;
+    /**
+     * Select the first field in the array automatically.
+     *
+     * @default true
+     */
+    autoSelectField?: boolean;
+    /**
+     * Select the first operator in the array automatically.
+     *
+     * @default true
+     */
+    autoSelectOperator?: boolean;
+    /**
+     * Adds a new default rule automatically to each new group.
+     *
+     * @default false
+     */
+    addRuleToNewGroups?: boolean;
+    /**
+     * Store list-type values as native arrays instead of comma-separated strings.
+     *
+     * @default false
+     */
+    listsAsArrays?: boolean;
+    /**
+     * Store values as numbers if possible.
+     *
+     * @default false
+     */
+    parseNumbers?: ParseNumbersMethod;
+    /**
+     * Disables the entire query builder if true, or the rules and groups at
+     * the specified paths (as well as all child rules/groups and subcomponents)
+     * if an array of paths is provided. If the root path is specified (`disabled={[[]]}`),
+     * no changes to the query are allowed.
+     *
+     * @default false
+     */
+    disabled?: boolean | Path[];
+    /**
+     * Query validation function.
+     */
+    validator?: QueryValidator;
+    /**
+     * `id` generator function. Should always produce a unique/random value.
+     *
+     * @default crypto.randomUUID
+     */
+    idGenerator?: () => string;
+    /**
+     * Generator function for the `title` attribute applied to the outermost `<div>` of each
+     * rule group. As this is intended to help with accessibility, the text output from this
+     * function should be meaningful, descriptive, and unique within the page.
+     */
+    accessibleDescriptionGenerator?: AccessibleDescriptionGenerator;
+    /**
+     * Container for custom props that are passed to all components.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    context?: any;
+  }
   : never;
 
 // import { getFirstOption } from '../utils';

--- a/packages/react-querybuilder/src/utils/queryTools.ts
+++ b/packages/react-querybuilder/src/utils/queryTools.ts
@@ -67,7 +67,7 @@ export const add = <RG extends RuleGroupTypeAny>(
         // to the rules array, but that happens immediately and unconditionally so
         // there's no significant risk.
         combinatorPreceding ??
-          (typeof prevCombinator === 'string' ? prevCombinator : getFirstOption(combinators))
+        (typeof prevCombinator === 'string' ? prevCombinator : getFirstOption(combinators))
       );
     }
     // `as RuleType` in only here to avoid the ambiguity with `RuleGroupTypeAny`
@@ -301,6 +301,12 @@ export interface MoveOptions {
    * ID generator.
    */
   idGenerator?: () => string;
+  /**
+   * Prop to set max grouping level
+   *
+   * @default Infinity
+   */
+  maxGroupLevel?: number;
 }
 /**
  * Moves a rule or group from one path to another. In the options parameter, pass
@@ -315,12 +321,13 @@ export const move = <RG extends RuleGroupTypeAny>(
   /** Path to move the rule or group to, or a shift direction. */
   newPath: Path | 'up' | 'down',
   /** Options. */
-  { clone = false, combinators = defaultCombinators, idGenerator = generateID }: MoveOptions = {}
+  { clone = false, combinators = defaultCombinators, idGenerator = generateID, maxGroupLevel = Infinity }: MoveOptions = {}
 ) => {
   const nextPath = getNextPath(query, oldPath, newPath);
 
   // Don't move to the same location or a path that doesn't exist yet
   if (
+    (maxGroupLevel !== Infinity && nextPath.length > maxGroupLevel) ||
     oldPath.length === 0 ||
     pathsAreEqual(oldPath, nextPath) ||
     !findPath(getParentPath(nextPath), query)

--- a/website/docs/typescript.md
+++ b/website/docs/typescript.md
@@ -313,6 +313,6 @@ interface QueryActions {
   ): void;
   onRuleAdd(rule: RuleType, parentPath: Path, context?: any): void;
   onRuleRemove(path: Path): void;
-  moveRule(oldPath: Path, newPath: Path, clone?: boolean): void;
+  moveRule(oldPath: Path, newPath: Path, clone?: boolean, maxGroupLevel?: number): void;
 }
 ```

--- a/website/versioned_docs/version-5/typescript.mdx
+++ b/website/versioned_docs/version-5/typescript.mdx
@@ -264,6 +264,6 @@ interface QueryActions {
   ): void;
   onRuleAdd(rule: RuleType, parentPath: number[]): void;
   onRuleRemove(path: number[]): void;
-  moveRule(oldPath: number[], newPath: number[], clone?: boolean): void;
+  moveRule(oldPath: number[], newPath: number[], clone?: boolean, maxGroupLevel?: number): void;
 }
 ```

--- a/website/versioned_docs/version-6/typescript.mdx
+++ b/website/versioned_docs/version-6/typescript.mdx
@@ -278,6 +278,6 @@ interface QueryActions {
   ): void;
   onRuleAdd(rule: RuleType, parentPath: Path, context?: any): void;
   onRuleRemove(path: Path): void;
-  moveRule(oldPath: Path, newPath: Path, clone?: boolean): void;
+  moveRule(oldPath: Path, newPath: Path, clone?: boolean, maxGroupLevel?: number): void;
 }
 ```

--- a/website/versioned_docs/version-7/typescript.md
+++ b/website/versioned_docs/version-7/typescript.md
@@ -313,6 +313,6 @@ interface QueryActions {
   ): void;
   onRuleAdd(rule: RuleType, parentPath: Path, context?: any): void;
   onRuleRemove(path: Path): void;
-  moveRule(oldPath: Path, newPath: Path, clone?: boolean): void;
+  moveRule(oldPath: Path, newPath: Path, clone?: boolean, maxGroupLevel?: number): void;
 }
 ```


### PR DESCRIPTION
As per [these docs](https://react-querybuilder.js.org/docs/tips/limit-groups), react-querybuilder does have support of limiting group levels but current support does not prevent  users completely from creating unexpected nesting. User can create unexpected nesting using drag and drop OR shift actions.

Quick screen-recording of issue - 
https://github.com/AbhishekThorat/react-querybuilder/assets/18628649/dd15eea7-74f9-46c8-a76d-e2f39cdcdcad

Possible fix implemented with this draft - Introduce a new prop variable to determine max group level.
https://github.com/AbhishekThorat/react-querybuilder/assets/18628649/1005c1e1-7f7e-4284-acab-957260701647


Todos prior submitting PR -
- [ ] Discuss the issue with react-querybuilder team and get go ahead for submitting PR
- [ ] Proper UI/UX treatment for failed shift/drag-and-drop actions.
- [ ] Self review
- [ ] Unit tests for new prop
- [ ] Testing with different scenarios
- [ ] Documentation changes
